### PR TITLE
.inputrc issue, repaired

### DIFF
--- a/inputrc
+++ b/inputrc
@@ -13,7 +13,7 @@ set editing-mode vi
 set show-all-if-ambiguous on
 set completion-ignore-case on
 # On menu-complete, display the common prefix, then cycle through the options with tab.
-menu-complete-display-prefix on
+set menu-complete-display-prefix on
 
 ####################################################################################################
 # Vi Command Mode Keymaps


### PR DESCRIPTION
I found that the character "p" was not functioning in the terminal after activating this dotfile, even when pasted into the terminal (example: ".xinputrc" became ".xinutrc"). Puzzled, I posted to reddit/r/commandline:

https://www.reddit.com/r/commandline/comments/3bovtd/help_ive_just_changed_my_inputrc_to_enable_vi/

and I was informed that at the beginning of line 16, "set" was missing. The issue has been resolved. :)

(thanks for your great dotfiles, they're a tremendous aid to a new Colemak user wrestling with Arch and Vim!)

[Apologies if I'm doing this wrong; this is my first time using Github, and I haven't learned all of the ropes yet. :P]
